### PR TITLE
Fix Supabase initialization guard

### DIFF
--- a/api.js
+++ b/api.js
@@ -28,8 +28,7 @@
           console.warn('Supabase script missing; extended features may not work. Falling back to localStorage.');
           throw new Error('supabase global missing');
         }
-        if (!window.supabase) { console.warn('Supabase script missing; offline mode.'); throw new Error('supabase missing'); }
-supa = window.supabase.createClient(SUPA_URL, SUPA_KEY);
+        supa = window.supabase.createClient(SUPA_URL, SUPA_KEY);
         // Get current session
         const { data: { session } } = await supa.auth.getSession();
         currentUser = session?.user || null;


### PR DESCRIPTION
## Summary
- remove the duplicate Supabase guard in api.js so the client initializes when the library loads

## Testing
- npx prettier --check index.html api.js

------
https://chatgpt.com/codex/tasks/task_e_68e3b039d0b88329b615238ff672c24f