### PR TITLE
Fix vendor workflow setup

### DIFF
--- a/.github/workflows/vendor-test-deploy.yml
+++ b/.github/workflows/vendor-test-deploy.yml
@@ -16,6 +16,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
 
       # 1) Vendor libs to /libs (no CDN at runtime)
       - name: Vendor browser libs
@@ -168,8 +174,7 @@ window.composeDocxBlobPatched = window.composeDocxBlob;
       - name: Install test deps
         run: |
           set -e
-          npm init -y >/dev/null 2>&1
-          npm install --no-audit --no-fund docxtemplater@3.66.6 pizzip@3.2.0 mammoth@1.11.0
+          npm install --no-audit --no-fund --no-save --package-lock=false docxtemplater@3.66.6 pizzip@3.2.0 mammoth@1.11.0
 
       - name: Create & run smoke test
         run: |
@@ -211,8 +216,15 @@ window.composeDocxBlobPatched = window.composeDocxBlob;
           JS
           node tests/smoke_test.js
 
+      - name: Clean up node modules
+        run: |
+          set -e
+          rm -rf node_modules package-lock.json package.json
+
       # 6) Commit changes back (idempotent)
       - name: Commit changes back
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
         run: |
           set -e
           git config user.name "github-actions[bot]"
@@ -220,7 +232,7 @@ window.composeDocxBlobPatched = window.composeDocxBlob;
           git add -A
           if ! git diff --staged --quiet; then
             git commit -m "PO Wizard: vendor local libs, normalize template, patch index.html, add smoke test"
-            git push
+            git push origin HEAD:"$BRANCH_NAME"
           else
             echo "No repo changes to commit."
           fi


### PR DESCRIPTION
## Summary
- check out the triggering branch with full history before running automation
- configure GitHub Pages prior to uploading the site artifact
- prevent npm installs from dirtying the repo and push back to the proper branch

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e667f7b82c83299b5823761184ec4b