### PR TITLE
Update test script to avoid failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "dana-po-wizard",
+  "version": "1.0.0",
+  "description": "Dana Energy Purchase Order/Contract Wizard",
+  "scripts": {
+    "test": "echo \"No tests yet\" && exit 0"
+  },
+  "author": "",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- add a project package.json that declares the Dana PO Wizard metadata
- adjust the npm test script so it no longer exits with an error by default

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e66f583e20832993ba47145f5dec55